### PR TITLE
Allowed fork digest flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,14 @@ RESOLVER_API_KEY=your_ip_data_key
 ```
 
 ### Configs and Flags
-Eth2 crawler support config through yaml files. Default yaml config is provided at `cmd/config/config.dev.yaml`. You can use your own config file by providing it's path using the `-p` flag 
+Eth2 crawler support config through yaml files. Default yaml config is provided at `cmd/config/config.dev.yaml`. You can use your own config file by providing it's path using the `-p` flag
+
+#### allowed-fork-digests
+You can use `allowed-fork-digests` flag to filter nodes by specific `Fork Digest`
+
+```shell
+./crawler --allowed-fork-digests 0xafcaaba0,0xe7acb210
+```
 
 ### Usage
 We use docker-compose for testing locally. Once you have defined the environment variable in the `.env` file, you can start the server using:

--- a/crawler/service.go
+++ b/crawler/service.go
@@ -11,12 +11,17 @@ import (
 	"eth2-crawler/store/record"
 
 	"github.com/ethereum/go-ethereum/log"
-
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/protolambda/zrnt/eth2/beacon/common"
 )
 
 // Start starts the crawler service
-func Start(peerStore peerstore.Provider, historyStore record.Provider, ipResolver ipResolver.Provider) {
+func Start(
+	peerStore peerstore.Provider,
+	historyStore record.Provider,
+	ipResolver ipResolver.Provider,
+	allowedForkDigest map[common.ForkDigest]struct{},
+) {
 	h := log.CallerFileHandler(log.StdoutHandler)
 	log.Root().SetHandler(h)
 
@@ -25,7 +30,7 @@ func Start(peerStore peerstore.Provider, historyStore record.Provider, ipResolve
 	)
 	log.Root().SetHandler(handler)
 
-	err := crawl.Initialize(peerStore, historyStore, ipResolver, params.V5Bootnodes)
+	err := crawl.Initialize(peerStore, historyStore, ipResolver, params.V5Bootnodes, allowedForkDigest)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
## Description
Added new `allowed-fork-digests` flag to filter nodes by specific `ForkDigest`.

### Usage:
```shell
./crawler --allowed-fork-digests 0xafcaaba0,0xe7acb210
```

#### Closes: #?
