### PR TITLE
fix:update peer with latest data

### DIFF
--- a/store/peerstore/mongo/mongo.go
+++ b/store/peerstore/mongo/mongo.go
@@ -49,7 +49,8 @@ func (s *mongoStore) Create(ctx context.Context, peer *models.Peer) error {
 		}
 		return err
 	}
-	return nil
+	// if found update the peer with the latest data
+	return s.Update(ctx, peer)
 }
 
 func (s *mongoStore) Update(ctx context.Context, peer *models.Peer) error {


### PR DESCRIPTION
A peer can be discovered many times while crawling. Also in each restart crawling start from the first. 
The DB schema changed in the latest pr merge. With this PR all the existing peer info will be updated gradually when we re discover them